### PR TITLE
feat(layout): add common layout component

### DIFF
--- a/src/components/common/Layout.test.tsx
+++ b/src/components/common/Layout.test.tsx
@@ -8,62 +8,91 @@
  */
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
-
-// TODO: Layoutコンポーネント実装後にインポートを有効化
-// import { Layout } from './Layout'
+import { Layout } from './Layout'
 
 describe('Layout', () => {
   describe('基本レンダリング', () => {
     it('Layoutコンポーネントが正しくレンダリングされる', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
-      // render(
-      //   <Layout>
-      //     <div data-testid="child">Child Content</div>
-      //   </Layout>
-      // )
-      // expect(screen.getByTestId('layout')).toBeInTheDocument()
+      render(
+        <Layout>
+          <div data-testid="child">Child Content</div>
+        </Layout>
+      )
+      expect(screen.getByTestId('layout')).toBeInTheDocument()
     })
 
     it('子要素が正しく表示される', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      render(
+        <Layout>
+          <div data-testid="child">Child Content</div>
+        </Layout>
+      )
+      expect(screen.getByTestId('child')).toBeInTheDocument()
+      expect(screen.getByTestId('child')).toHaveTextContent('Child Content')
     })
   })
 
   describe('ヘッダー', () => {
     it('ヘッダーが表示される', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      render(
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      )
+      expect(screen.getByTestId('header')).toBeInTheDocument()
     })
 
     it('ロゴが表示される', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      render(
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      )
+      expect(screen.getByTestId('logo')).toBeInTheDocument()
     })
   })
 
   describe('フッター', () => {
     it('フッターが表示される', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      render(
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      )
+      expect(screen.getByTestId('footer')).toBeInTheDocument()
     })
 
     it('コピーライトが表示される', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      render(
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      )
+      expect(screen.getByTestId('copyright')).toBeInTheDocument()
+      expect(screen.getByTestId('copyright')).toHaveTextContent('© 2025 Hackz-Ptera')
     })
   })
 
   describe('レスポンシブ対応', () => {
     it('モバイル表示で適切なスタイルが適用される', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      render(
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      )
+      const layout = screen.getByTestId('layout')
+      expect(layout).toHaveClass('min-h-screen', 'flex', 'flex-col')
     })
 
     it('デスクトップ表示で適切なスタイルが適用される', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      render(
+        <Layout>
+          <div>Content</div>
+        </Layout>
+      )
+      const layout = screen.getByTestId('layout')
+      expect(layout).toHaveClass('min-h-screen', 'flex', 'flex-col')
     })
   })
 })
+

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -1,0 +1,51 @@
+/**
+ * Layout - 共通レイアウトコンポーネント
+ * Issue #2: 共通レイアウトコンポーネント
+ * 
+ * 全ページで使用する共通レイアウト
+ * - ヘッダー（アプリタイトル、ロゴ）
+ * - コンテンツエリア
+ * - フッター（コピーライト）
+ */
+
+interface LayoutProps {
+    children: React.ReactNode
+}
+
+export const Layout = ({ children }: LayoutProps) => {
+    return (
+        <div data-testid="layout" className="min-h-screen flex flex-col bg-gray-900 text-white">
+            {/* ヘッダー */}
+            <header data-testid="header" className="bg-gray-800 border-b border-gray-700 px-4 py-4 md:px-8">
+                <div className="max-w-7xl mx-auto flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                        {/* ロゴ */}
+                        <div data-testid="logo" className="text-2xl">
+                            🦖
+                        </div>
+                        {/* アプリタイトル */}
+                        <h1 className="text-xl md:text-2xl font-bold">
+                            The Frustrating Registration Form
+                        </h1>
+                    </div>
+                </div>
+            </header>
+
+            {/* コンテンツエリア */}
+            <main className="flex-1">
+                {children}
+            </main>
+
+            {/* フッター */}
+            <footer data-testid="footer" className="bg-gray-800 border-t border-gray-700 px-4 py-4 md:px-8">
+                <div className="max-w-7xl mx-auto text-center text-sm text-gray-400">
+                    <p data-testid="copyright">
+                        © 2025 Hackz-Ptera. All rights reserved.
+                    </p>
+                </div>
+            </footer>
+        </div>
+    )
+}
+
+export default Layout


### PR DESCRIPTION
- Implement Layout component with header, footer, and content area
- Add responsive design with Tailwind CSS
- Include logo and app title in header
- Add copyright in footer
- Enable all tests in Layout.test.tsx (8/8 passing)

Closes #2