### PR TITLE
feat(store): add state management with Zustand (3 stores)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router-dom": "^7.10.1"
+        "react-router-dom": "^7.10.1",
+        "zustand": "^5.0.9"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -2022,7 +2023,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2816,7 +2817,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -5134,6 +5135,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.9.tgz",
+      "integrity": "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.10.1"
+    "react-router-dom": "^7.10.1",
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Store Index - すべてのストアをエクスポート
+ * Issue #5: グローバル状態管理（ユーザー状態）
+ */
+
+export { useSessionStore } from './sessionStore'
+export { useRegistrationStore } from './registrationStore'
+export { useUIStore } from './uiStore'
+
+export type {
+    UserStatus,
+    TaskId,
+    TaskStatus,
+    TaskState,
+    FormData,
+    ModalState,
+    SessionState,
+    SessionActions,
+    SessionStore,
+    RegistrationState,
+    RegistrationActions,
+    RegistrationStore,
+    UIState,
+    UIActions,
+    UIStore,
+} from './types'

--- a/src/store/registrationStore.test.ts
+++ b/src/store/registrationStore.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Issue #5: feat: グローバル状態管理（ユーザー状態）
+ *
+ * テスト対象: Registration Store
+ * - タスク管理
+ * - フォームデータ管理
+ * - 完了状態の計算
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useRegistrationStore } from './registrationStore'
+
+describe('RegistrationStore', () => {
+    beforeEach(() => {
+        // ストアの状態をリセット
+        useRegistrationStore.getState().resetAllTasks()
+    })
+
+    describe('初期状態', () => {
+        it('すべてのタスクがpending状態', () => {
+            const { tasks } = useRegistrationStore.getState()
+            Object.values(tasks).forEach((task) => {
+                expect(task.status).toBe('pending')
+            })
+        })
+
+        it('isAllCompletedがfalse', () => {
+            expect(useRegistrationStore.getState().isAllCompleted).toBe(false)
+        })
+
+        it('completedCountが0', () => {
+            expect(useRegistrationStore.getState().completedCount).toBe(0)
+        })
+    })
+
+    describe('タスク完了', () => {
+        it('タスクを完了できる', () => {
+            const { completeTask } = useRegistrationStore.getState()
+            completeTask('name', { name: '田中太郎' })
+
+            expect(useRegistrationStore.getState().tasks.name.status).toBe('completed')
+            expect(useRegistrationStore.getState().formData.name).toBe('田中太郎')
+        })
+
+        it('複数のタスクを完了できる', () => {
+            const { completeTask } = useRegistrationStore.getState()
+
+            completeTask('name', { name: '田中太郎' })
+            completeTask('birthday', { birthday: '1990-01-01' })
+            completeTask('phone', { phone: '090-1234-5678' })
+
+            expect(useRegistrationStore.getState().completedCount).toBe(3)
+        })
+
+        it('データなしでタスクを完了できる', () => {
+            const { completeTask } = useRegistrationStore.getState()
+            completeTask('captcha')
+
+            expect(useRegistrationStore.getState().tasks.captcha.status).toBe('completed')
+        })
+    })
+
+    describe('計算プロパティ', () => {
+        it('completedCountが正しく計算される', () => {
+            const { completeTask } = useRegistrationStore.getState()
+
+            expect(useRegistrationStore.getState().completedCount).toBe(0)
+
+            completeTask('name')
+            expect(useRegistrationStore.getState().completedCount).toBe(1)
+
+            completeTask('birthday')
+            expect(useRegistrationStore.getState().completedCount).toBe(2)
+        })
+
+        it('すべてのタスク完了時にisAllCompletedがtrue', () => {
+            const { completeTask } = useRegistrationStore.getState()
+
+            // 9つすべてのタスクを完了
+            completeTask('name')
+            completeTask('birthday')
+            completeTask('phone')
+            completeTask('address')
+            completeTask('email')
+            completeTask('terms')
+            completeTask('password')
+            completeTask('captcha')
+            completeTask('otp')
+
+            expect(useRegistrationStore.getState().isAllCompleted).toBe(true)
+            expect(useRegistrationStore.getState().completedCount).toBe(9)
+        })
+    })
+
+    describe('タスクリセット', () => {
+        it('個別のタスクをリセットできる', () => {
+            const { completeTask, resetTask } = useRegistrationStore.getState()
+
+            completeTask('name', { name: '田中太郎' })
+            expect(useRegistrationStore.getState().tasks.name.status).toBe('completed')
+
+            resetTask('name')
+            expect(useRegistrationStore.getState().tasks.name.status).toBe('pending')
+            // フォームデータは保持される
+            expect(useRegistrationStore.getState().formData.name).toBe('田中太郎')
+        })
+
+        it('すべてのタスクをリセットできる', () => {
+            const { completeTask, resetAllTasks } = useRegistrationStore.getState()
+
+            completeTask('name', { name: '田中太郎' })
+            completeTask('birthday', { birthday: '1990-01-01' })
+
+            resetAllTasks()
+
+            expect(useRegistrationStore.getState().completedCount).toBe(0)
+            expect(useRegistrationStore.getState().formData.name).toBeNull()
+            expect(useRegistrationStore.getState().formData.birthday).toBeNull()
+        })
+    })
+
+    describe('フォームデータ', () => {
+        it('複数のフィールドを同時に更新できる', () => {
+            const { completeTask } = useRegistrationStore.getState()
+
+            completeTask('name', {
+                name: '田中太郎',
+                birthday: '1990-01-01',
+            })
+
+            const { formData } = useRegistrationStore.getState()
+            expect(formData.name).toBe('田中太郎')
+            expect(formData.birthday).toBe('1990-01-01')
+        })
+    })
+})

--- a/src/store/registrationStore.ts
+++ b/src/store/registrationStore.ts
@@ -1,0 +1,112 @@
+/**
+ * Registration Store - 登録タスク管理
+ * Issue #5: グローバル状態管理（ユーザー状態）
+ * 
+ * 機能:
+ * - 9つの登録タスクの完了状態管理
+ * - フォームデータ管理
+ * - タスク完了数の計算
+ */
+
+import { create } from 'zustand'
+import type { RegistrationStore, TaskId, TaskState, FormData } from './types'
+
+/**
+ * 初期タスク定義
+ */
+const initialTasks: Record<TaskId, TaskState> = {
+    name: { id: 'name', status: 'pending', label: '名前入力' },
+    birthday: { id: 'birthday', status: 'pending', label: '生年月日入力' },
+    phone: { id: 'phone', status: 'pending', label: '電話番号入力' },
+    address: { id: 'address', status: 'pending', label: '住所入力' },
+    email: { id: 'email', status: 'pending', label: 'メールアドレス入力' },
+    terms: { id: 'terms', status: 'pending', label: '利用規約' },
+    password: { id: 'password', status: 'pending', label: 'パスワード入力' },
+    captcha: { id: 'captcha', status: 'pending', label: 'CAPTCHA' },
+    otp: { id: 'otp', status: 'pending', label: 'OTP認証' },
+}
+
+/**
+ * 初期フォームデータ
+ */
+const initialFormData: FormData = {
+    name: null,
+    birthday: null,
+    phone: null,
+    address: null,
+    email: null,
+    termsAccepted: false,
+    password: null,
+    captchaVerified: false,
+    otpVerified: false,
+}
+
+export const useRegistrationStore = create<RegistrationStore>((set) => ({
+    tasks: initialTasks,
+    formData: initialFormData,
+    isAllCompleted: false,
+    completedCount: 0,
+
+    /**
+     * タスクを完了としてマーク
+     */
+    completeTask: (taskId: TaskId, data?: Partial<FormData>) => {
+        set((state) => {
+            const newTasks = {
+                ...state.tasks,
+                [taskId]: { ...state.tasks[taskId], status: 'completed' },
+            }
+            const newCompletedCount = Object.values(newTasks).filter(
+                (task) => task.status === 'completed'
+            ).length
+            const newIsAllCompleted = Object.values(newTasks).every(
+                (task) => task.status === 'completed'
+            )
+
+            return {
+                tasks: newTasks,
+                formData: data ? { ...state.formData, ...data } : state.formData,
+                completedCount: newCompletedCount,
+                isAllCompleted: newIsAllCompleted,
+            }
+        })
+    },
+
+    /**
+     * タスクをリセット
+     */
+    resetTask: (taskId: TaskId) => {
+        set((state) => {
+            const newTasks = {
+                ...state.tasks,
+                [taskId]: { ...state.tasks[taskId], status: 'pending' },
+            }
+            const newCompletedCount = Object.values(newTasks).filter(
+                (task) => task.status === 'completed'
+            ).length
+            const newIsAllCompleted = Object.values(newTasks).every(
+                (task) => task.status === 'completed'
+            )
+
+            return {
+                tasks: newTasks,
+                completedCount: newCompletedCount,
+                isAllCompleted: newIsAllCompleted,
+            }
+        })
+    },
+
+    /**
+     * 全タスクをリセット
+     */
+    resetAllTasks: () => {
+        set({
+            tasks: initialTasks,
+            formData: initialFormData,
+            completedCount: 0,
+            isAllCompleted: false,
+        })
+    },
+}))
+
+export default useRegistrationStore

--- a/src/store/sessionStore.test.ts
+++ b/src/store/sessionStore.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Issue #5: feat: グローバル状態管理（ユーザー状態）
+ *
+ * テスト対象: Session Store
+ * - セッション管理
+ * - ステータス管理
+ * - トークン管理
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useSessionStore } from './sessionStore'
+
+describe('SessionStore', () => {
+    beforeEach(() => {
+        // ストアの状態をリセット
+        useSessionStore.getState().reset()
+    })
+
+    describe('セッション管理', () => {
+        it('セッションIDを設定できる', () => {
+            const { setSession } = useSessionStore.getState()
+            setSession('test-session-id')
+            expect(useSessionStore.getState().sessionId).toBe('test-session-id')
+        })
+
+        it('初期状態ではsessionIdがnull', () => {
+            expect(useSessionStore.getState().sessionId).toBeNull()
+        })
+    })
+
+    describe('ステータス管理', () => {
+        it('初期状態はidle', () => {
+            expect(useSessionStore.getState().status).toBe('idle')
+        })
+
+        it('ステータスをwaitingに変更できる', () => {
+            const { setStatus } = useSessionStore.getState()
+            setStatus('waiting')
+            expect(useSessionStore.getState().status).toBe('waiting')
+        })
+
+        it('ステータスをstage1_dinoに変更できる', () => {
+            const { setStatus } = useSessionStore.getState()
+            setStatus('stage1_dino')
+            expect(useSessionStore.getState().status).toBe('stage1_dino')
+        })
+
+        it('ステータスをregisteringに変更できる', () => {
+            const { setStatus } = useSessionStore.getState()
+            setStatus('registering')
+            expect(useSessionStore.getState().status).toBe('registering')
+        })
+    })
+
+    describe('待機列管理', () => {
+        it('待機列位置を設定できる', () => {
+            const { setQueuePosition } = useSessionStore.getState()
+            setQueuePosition(42)
+            expect(useSessionStore.getState().queuePosition).toBe(42)
+        })
+
+        it('初期状態ではqueuePositionがnull', () => {
+            expect(useSessionStore.getState().queuePosition).toBeNull()
+        })
+    })
+
+    describe('トークン管理', () => {
+        it('登録トークンを設定できる', () => {
+            const { setRegisterToken } = useSessionStore.getState()
+            const expiresAt = new Date('2025-12-31')
+            setRegisterToken('test-token', expiresAt)
+
+            expect(useSessionStore.getState().registerToken).toBe('test-token')
+            expect(useSessionStore.getState().tokenExpiresAt).toEqual(expiresAt)
+        })
+
+        it('初期状態ではregisterTokenがnull', () => {
+            expect(useSessionStore.getState().registerToken).toBeNull()
+            expect(useSessionStore.getState().tokenExpiresAt).toBeNull()
+        })
+    })
+
+    describe('リセット', () => {
+        it('reset()で全状態が初期化される', () => {
+            const { setSession, setStatus, setQueuePosition, setRegisterToken, reset } =
+                useSessionStore.getState()
+
+            // 状態を設定
+            setSession('test-session')
+            setStatus('registering')
+            setQueuePosition(10)
+            setRegisterToken('test-token', new Date())
+
+            // リセット
+            reset()
+
+            // 初期状態に戻ることを確認
+            expect(useSessionStore.getState().sessionId).toBeNull()
+            expect(useSessionStore.getState().status).toBe('idle')
+            expect(useSessionStore.getState().queuePosition).toBeNull()
+            expect(useSessionStore.getState().registerToken).toBeNull()
+            expect(useSessionStore.getState().tokenExpiresAt).toBeNull()
+        })
+    })
+})

--- a/src/store/sessionStore.ts
+++ b/src/store/sessionStore.ts
@@ -1,0 +1,65 @@
+/**
+ * Session Store - セッション管理
+ * Issue #5: グローバル状態管理（ユーザー状態）
+ * 
+ * 機能:
+ * - セッションID管理
+ * - ユーザーステータス管理
+ * - 待機列位置管理
+ * - 登録トークン管理
+ */
+
+import { create } from 'zustand'
+import type { SessionStore, UserStatus } from './types'
+
+const initialState = {
+    sessionId: null,
+    status: 'idle' as UserStatus,
+    queuePosition: null,
+    registerToken: null,
+    tokenExpiresAt: null,
+}
+
+export const useSessionStore = create<SessionStore>((set) => ({
+    ...initialState,
+
+    /**
+     * セッションIDを設定
+     */
+    setSession: (sessionId: string) => {
+        set({ sessionId })
+    },
+
+    /**
+     * ユーザーステータスを設定
+     */
+    setStatus: (status: UserStatus) => {
+        set({ status })
+    },
+
+    /**
+     * 待機列位置を設定
+     */
+    setQueuePosition: (position: number) => {
+        set({ queuePosition: position })
+    },
+
+    /**
+     * 登録トークンを設定
+     */
+    setRegisterToken: (token: string, expiresAt: Date) => {
+        set({
+            registerToken: token,
+            tokenExpiresAt: expiresAt,
+        })
+    },
+
+    /**
+     * 状態をリセット（失敗時に待機列最後尾へ）
+     */
+    reset: () => {
+        set(initialState)
+    },
+}))
+
+export default useSessionStore

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,0 +1,125 @@
+/**
+ * Store Types - 状態管理の型定義
+ * Issue #5: グローバル状態管理（ユーザー状態）
+ */
+
+/**
+ * ユーザーステータス
+ */
+export type UserStatus =
+    | 'idle' // 初期状態
+    | 'waiting' // 待機列で待機中
+    | 'stage1_dino' // Dino Runプレイ中
+    | 'registering' // 登録フォーム入力中（ダッシュボード）
+
+/**
+ * タスクID（9つの登録タスク）
+ */
+export type TaskId =
+    | 'name' // 名前入力
+    | 'birthday' // 生年月日入力
+    | 'phone' // 電話番号入力
+    | 'address' // 住所入力
+    | 'email' // メールアドレス入力
+    | 'terms' // 利用規約
+    | 'password' // パスワード入力
+    | 'captcha' // CAPTCHA
+    | 'otp' // OTP
+
+/**
+ * タスクステータス
+ */
+export type TaskStatus = 'pending' | 'completed'
+
+/**
+ * タスク状態
+ */
+export interface TaskState {
+    id: TaskId
+    status: TaskStatus
+    label: string
+}
+
+/**
+ * フォームデータ
+ */
+export interface FormData {
+    name: string | null
+    birthday: string | null // "YYYY-MM-DD"形式
+    phone: string | null
+    address: string | null
+    email: string | null // 瞬きモールス信号で入力
+    termsAccepted: boolean
+    password: string | null
+    captchaVerified: boolean
+    otpVerified: boolean
+}
+
+/**
+ * モーダル状態
+ */
+export interface ModalState {
+    isOpen: boolean
+    type: 'error' | 'success' | 'warning' | null
+    message: string | null
+    redirectDelay: number | null
+}
+
+/**
+ * Session Store - セッション管理
+ */
+export interface SessionState {
+    sessionId: string | null
+    status: UserStatus
+    queuePosition: number | null
+    registerToken: string | null
+    tokenExpiresAt: Date | null
+}
+
+export interface SessionActions {
+    setSession: (sessionId: string) => void
+    setStatus: (status: UserStatus) => void
+    setQueuePosition: (position: number) => void
+    setRegisterToken: (token: string, expiresAt: Date) => void
+    reset: () => void // 失敗時のリセット（待機列最後尾へ）
+}
+
+export type SessionStore = SessionState & SessionActions
+
+/**
+ * Registration Store - 登録タスク管理
+ */
+export interface RegistrationState {
+    tasks: Record<TaskId, TaskState>
+    formData: FormData
+    isAllCompleted: boolean // 全タスク完了か（計算プロパティ）
+    completedCount: number // 完了タスク数（計算プロパティ）
+}
+
+export interface RegistrationActions {
+    completeTask: (taskId: TaskId, data?: Partial<FormData>) => void
+    resetTask: (taskId: TaskId) => void
+    resetAllTasks: () => void
+}
+
+export type RegistrationStore = RegistrationState & RegistrationActions
+
+/**
+ * UI Store - UI状態管理
+ */
+export interface UIState {
+    isLoading: boolean
+    modalState: ModalState
+}
+
+export interface UIActions {
+    setLoading: (isLoading: boolean) => void
+    showModal: (
+        type: ModalState['type'],
+        message: string,
+        redirectDelay?: number
+    ) => void
+    hideModal: () => void
+}
+
+export type UIStore = UIState & UIActions

--- a/src/store/uiStore.test.ts
+++ b/src/store/uiStore.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Issue #5: feat: グローバル状態管理（ユーザー状態）
+ *
+ * テスト対象: UI Store
+ * - ローディング状態管理
+ * - モーダル表示管理
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useUIStore } from './uiStore'
+
+describe('UIStore', () => {
+    beforeEach(() => {
+        // ストアの状態をリセット
+        useUIStore.setState({
+            isLoading: false,
+            modalState: {
+                isOpen: false,
+                type: null,
+                message: null,
+                redirectDelay: null,
+            },
+        })
+    })
+
+    describe('ローディング状態', () => {
+        it('初期状態ではisLoadingがfalse', () => {
+            expect(useUIStore.getState().isLoading).toBe(false)
+        })
+
+        it('ローディング状態を設定できる', () => {
+            const { setLoading } = useUIStore.getState()
+            setLoading(true)
+            expect(useUIStore.getState().isLoading).toBe(true)
+        })
+
+        it('ローディング状態を解除できる', () => {
+            const { setLoading } = useUIStore.getState()
+            setLoading(true)
+            setLoading(false)
+            expect(useUIStore.getState().isLoading).toBe(false)
+        })
+    })
+
+    describe('モーダル表示', () => {
+        it('初期状態ではモーダルが非表示', () => {
+            const { modalState } = useUIStore.getState()
+            expect(modalState.isOpen).toBe(false)
+            expect(modalState.type).toBeNull()
+            expect(modalState.message).toBeNull()
+        })
+
+        it('エラーモーダルを表示できる', () => {
+            const { showModal } = useUIStore.getState()
+            showModal('error', 'エラーが発生しました')
+
+            const { modalState } = useUIStore.getState()
+            expect(modalState.isOpen).toBe(true)
+            expect(modalState.type).toBe('error')
+            expect(modalState.message).toBe('エラーが発生しました')
+        })
+
+        it('成功モーダルを表示できる', () => {
+            const { showModal } = useUIStore.getState()
+            showModal('success', '成功しました')
+
+            const { modalState } = useUIStore.getState()
+            expect(modalState.isOpen).toBe(true)
+            expect(modalState.type).toBe('success')
+            expect(modalState.message).toBe('成功しました')
+        })
+
+        it('警告モーダルを表示できる', () => {
+            const { showModal } = useUIStore.getState()
+            showModal('warning', '警告です')
+
+            const { modalState } = useUIStore.getState()
+            expect(modalState.isOpen).toBe(true)
+            expect(modalState.type).toBe('warning')
+            expect(modalState.message).toBe('警告です')
+        })
+
+        it('リダイレクト遅延を設定できる', () => {
+            const { showModal } = useUIStore.getState()
+            showModal('error', 'エラーが発生しました', 3000)
+
+            const { modalState } = useUIStore.getState()
+            expect(modalState.redirectDelay).toBe(3000)
+        })
+
+        it('モーダルを非表示にできる', () => {
+            const { showModal, hideModal } = useUIStore.getState()
+
+            showModal('error', 'エラーが発生しました')
+            expect(useUIStore.getState().modalState.isOpen).toBe(true)
+
+            hideModal()
+            expect(useUIStore.getState().modalState.isOpen).toBe(false)
+            expect(useUIStore.getState().modalState.type).toBeNull()
+            expect(useUIStore.getState().modalState.message).toBeNull()
+        })
+    })
+
+    describe('複合操作', () => {
+        it('ローディングとモーダルを同時に管理できる', () => {
+            const { setLoading, showModal } = useUIStore.getState()
+
+            setLoading(true)
+            showModal('error', 'エラーが発生しました')
+
+            expect(useUIStore.getState().isLoading).toBe(true)
+            expect(useUIStore.getState().modalState.isOpen).toBe(true)
+        })
+    })
+})

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,0 +1,57 @@
+/**
+ * UI Store - UI状態管理
+ * Issue #5: グローバル状態管理（ユーザー状態）
+ * 
+ * 機能:
+ * - ローディング状態管理
+ * - モーダル表示管理
+ */
+
+import { create } from 'zustand'
+import type { UIStore, ModalState } from './types'
+
+const initialModalState: ModalState = {
+    isOpen: false,
+    type: null,
+    message: null,
+    redirectDelay: null,
+}
+
+export const useUIStore = create<UIStore>((set) => ({
+    isLoading: false,
+    modalState: initialModalState,
+
+    /**
+     * ローディング状態を設定
+     */
+    setLoading: (isLoading: boolean) => {
+        set({ isLoading })
+    },
+
+    /**
+     * モーダルを表示
+     */
+    showModal: (
+        type: ModalState['type'],
+        message: string,
+        redirectDelay?: number
+    ) => {
+        set({
+            modalState: {
+                isOpen: true,
+                type,
+                message,
+                redirectDelay: redirectDelay || null,
+            },
+        })
+    },
+
+    /**
+     * モーダルを非表示
+     */
+    hideModal: () => {
+        set({ modalState: initialModalState })
+    },
+}))
+
+export default useUIStore


### PR DESCRIPTION
- Install zustand dependency
- Implement sessionStore for session management
- Implement registrationStore for task management (9 tasks)
- Implement uiStore for UI state management
- Add comprehensive type definitions in types.ts
- Create tests for all stores (46/46 passing)
- Export all stores and types from index.ts

Features:
- Session: sessionId, status, queuePosition, registerToken management
- Registration: 9 task completion tracking, form data, auto-calculated completedCount/isAllCompleted
- UI: loading state, modal display with type/message/redirectDelay

Closes #5