### PR TITLE
feat(hooks): 自動リダイレクト機能を追加

### DIFF
--- a/src/hooks/useAutoRedirect.test.ts
+++ b/src/hooks/useAutoRedirect.test.ts
@@ -7,10 +7,8 @@
  * - リダイレクトキャンセル
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { renderHook, act, waitFor } from '@testing-library/react'
-
-// TODO: useAutoRedirectフック実装後にインポートを有効化
-// import { useAutoRedirect } from './useAutoRedirect'
+import { renderHook, act } from '@testing-library/react'
+import { useAutoRedirect } from './useAutoRedirect'
 
 const mockNavigate = vi.fn()
 
@@ -30,74 +28,182 @@ describe('useAutoRedirect', () => {
 
   describe('自動リダイレクト', () => {
     it('指定時間後にリダイレクトする', async () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
-      // const { result } = renderHook(() => useAutoRedirect({ to: '/next', delay: 5000 }))
-      // act(() => vi.advanceTimersByTime(5000))
-      // expect(mockNavigate).toHaveBeenCalledWith('/next')
+      renderHook(() => useAutoRedirect({ to: '/next', delay: 5000 }))
+
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      expect(mockNavigate).toHaveBeenCalledWith('/next')
     })
 
     it('リダイレクト先を指定できる', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      renderHook(() => useAutoRedirect({ to: '/custom', delay: 3000 }))
+
+      act(() => {
+        vi.advanceTimersByTime(3000)
+      })
+
+      expect(mockNavigate).toHaveBeenCalledWith('/custom')
     })
 
     it('遅延時間を指定できる', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      renderHook(() => useAutoRedirect({ to: '/next', delay: 10000 }))
+
+      act(() => {
+        vi.advanceTimersByTime(9999)
+      })
+      expect(mockNavigate).not.toHaveBeenCalled()
+
+      act(() => {
+        vi.advanceTimersByTime(1)
+      })
+      expect(mockNavigate).toHaveBeenCalled()
     })
   })
 
   describe('カウントダウン', () => {
     it('残り秒数を返す', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      const { result } = renderHook(() =>
+        useAutoRedirect({ to: '/next', delay: 5000 })
+      )
+      expect(result.current.remainingSeconds).toBe(5)
     })
 
     it('1秒ごとにカウントダウンする', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      const { result } = renderHook(() =>
+        useAutoRedirect({ to: '/next', delay: 5000 })
+      )
+
+      expect(result.current.remainingSeconds).toBe(5)
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(result.current.remainingSeconds).toBe(4)
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(result.current.remainingSeconds).toBe(3)
     })
 
     it('0になったらリダイレクトする', async () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      const { result } = renderHook(() =>
+        useAutoRedirect({ to: '/next', delay: 3000 })
+      )
+
+      act(() => {
+        vi.advanceTimersByTime(3000)
+      })
+
+      expect(result.current.remainingSeconds).toBe(0)
+      expect(mockNavigate).toHaveBeenCalledWith('/next')
     })
   })
 
   describe('リダイレクトキャンセル', () => {
     it('キャンセル関数でリダイレクトをキャンセルできる', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      const { result } = renderHook(() =>
+        useAutoRedirect({ to: '/next', delay: 5000 })
+      )
+
+      act(() => {
+        result.current.cancel()
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      expect(mockNavigate).not.toHaveBeenCalled()
     })
 
     it('キャンセル後はカウントダウンが停止する', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      const { result } = renderHook(() =>
+        useAutoRedirect({ to: '/next', delay: 5000 })
+      )
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(result.current.remainingSeconds).toBe(4)
+
+      act(() => {
+        result.current.cancel()
+      })
+
+      act(() => {
+        vi.advanceTimersByTime(2000)
+      })
+      expect(result.current.remainingSeconds).toBe(4) // 停止している
     })
 
     it('キャンセル後に再開できる', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      const { result } = renderHook(() =>
+        useAutoRedirect({ to: '/next', delay: 5000, autoStart: false })
+      )
+
+      act(() => {
+        result.current.start()
+      })
+      expect(result.current.isRedirecting).toBe(true)
+
+      act(() => {
+        result.current.cancel()
+      })
+      expect(result.current.isRedirecting).toBe(false)
+
+      act(() => {
+        result.current.start()
+      })
+      expect(result.current.isRedirecting).toBe(true)
     })
   })
 
   describe('コールバック', () => {
     it('リダイレクト前にコールバックが呼ばれる', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      const onBeforeRedirect = vi.fn()
+      renderHook(() =>
+        useAutoRedirect({ to: '/next', delay: 3000, onBeforeRedirect })
+      )
+
+      act(() => {
+        vi.advanceTimersByTime(3000)
+      })
+
+      expect(onBeforeRedirect).toHaveBeenCalled()
     })
 
     it('コールバックでリダイレクトをキャンセルできる', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      const onBeforeRedirect = vi.fn(() => false)
+      renderHook(() =>
+        useAutoRedirect({ to: '/next', delay: 3000, onBeforeRedirect })
+      )
+
+      act(() => {
+        vi.advanceTimersByTime(3000)
+      })
+
+      expect(onBeforeRedirect).toHaveBeenCalled()
+      expect(mockNavigate).not.toHaveBeenCalled()
     })
   })
 
   describe('クリーンアップ', () => {
     it('コンポーネントアンマウント時にタイマーがクリアされる', () => {
-      // TODO: 実装後にテストを有効化
-      expect(true).toBe(true)
+      const { unmount } = renderHook(() =>
+        useAutoRedirect({ to: '/next', delay: 5000 })
+      )
+
+      unmount()
+
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      expect(mockNavigate).not.toHaveBeenCalled()
     })
   })
 })
+

--- a/src/hooks/useAutoRedirect.ts
+++ b/src/hooks/useAutoRedirect.ts
@@ -1,0 +1,115 @@
+/**
+ * useAutoRedirect - 自動リダイレクトカスタムhook
+ * Issue #28: 自動リダイレクト機能
+ * 
+ * 機能:
+ * - 指定時間後に自動リダイレクト
+ * - カウントダウン表示
+ * - リダイレクトキャンセル
+ * - リダイレクト前のコールバック
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export interface UseAutoRedirectOptions {
+    /** リダイレクト先のパス */
+    to: string
+    /** 遅延時間（ミリ秒） */
+    delay: number
+    /** リダイレクト前のコールバック（falseを返すとキャンセル） */
+    onBeforeRedirect?: () => boolean | void
+    /** 自動開始するか */
+    autoStart?: boolean
+}
+
+export interface UseAutoRedirectReturn {
+    /** 残り秒数 */
+    remainingSeconds: number
+    /** リダイレクトをキャンセル */
+    cancel: () => void
+    /** リダイレクトを開始 */
+    start: () => void
+    /** リダイレクト中かどうか */
+    isRedirecting: boolean
+}
+
+export const useAutoRedirect = ({
+    to,
+    delay,
+    onBeforeRedirect,
+    autoStart = true,
+}: UseAutoRedirectOptions): UseAutoRedirectReturn => {
+    const navigate = useNavigate()
+    const [remainingSeconds, setRemainingSeconds] = useState(
+        Math.ceil(delay / 1000)
+    )
+    const [isRedirecting, setIsRedirecting] = useState(autoStart)
+    const timerRef = useRef<number | undefined>(undefined)
+    const countdownRef = useRef<number | undefined>(undefined)
+
+    const cancel = useCallback(() => {
+        setIsRedirecting(false)
+        if (timerRef.current) {
+            clearTimeout(timerRef.current)
+            timerRef.current = undefined
+        }
+        if (countdownRef.current) {
+            clearInterval(countdownRef.current)
+            countdownRef.current = undefined
+        }
+    }, [])
+
+    const start = useCallback(() => {
+        setIsRedirecting(true)
+        setRemainingSeconds(Math.ceil(delay / 1000))
+    }, [delay])
+
+    useEffect(() => {
+        if (!isRedirecting) return
+
+        // カウントダウン
+        countdownRef.current = window.setInterval(() => {
+            setRemainingSeconds((prev) => {
+                const next = prev - 1
+                if (next <= 0) {
+                    if (countdownRef.current) {
+                        clearInterval(countdownRef.current)
+                    }
+                }
+                return Math.max(0, next)
+            })
+        }, 1000)
+
+        // リダイレクト
+        timerRef.current = window.setTimeout(() => {
+            // コールバックがfalseを返したらキャンセル
+            if (onBeforeRedirect) {
+                const result = onBeforeRedirect()
+                if (result === false) {
+                    cancel()
+                    return
+                }
+            }
+            navigate(to)
+        }, delay)
+
+        return () => {
+            if (timerRef.current) {
+                clearTimeout(timerRef.current)
+            }
+            if (countdownRef.current) {
+                clearInterval(countdownRef.current)
+            }
+        }
+    }, [isRedirecting, to, delay, navigate, onBeforeRedirect, cancel])
+
+    return {
+        remainingSeconds,
+        cancel,
+        start,
+        isRedirecting,
+    }
+}
+
+export default useAutoRedirect


### PR DESCRIPTION
- useAutoRedirect hookを実装
- 指定時間後の自動リダイレクト機能
- カウントダウン表示機能
- リダイレクトキャンセル機能
- リダイレクト前のコールバック
- テスト 12/12 passing

機能:
- redirect_delay対応（ミリ秒指定）
- 残り秒数のリアルタイム表示
- キャンセル・再開機能
- コールバックでfalseを返すとキャンセル可能
- クリーンアップ処理

Closes #28