### PR TITLE
feat(register): add registration complete error page with server erro…

### DIFF
--- a/src/api/registerApi.ts
+++ b/src/api/registerApi.ts
@@ -1,0 +1,123 @@
+/**
+ * Register API - 会員登録API
+ * Issue #24: 登録完了処理（サーバーエラー演出）
+ * 
+ * 鬼畜仕様: すべてのバリデーションが成功しても、必ずサーバーエラーが返る。
+ * 永遠に登録は完了しない。
+ */
+
+// --- 型定義 ---
+
+/**
+ * 登録リクエスト
+ */
+export interface RegisterRequest {
+    // フォームデータ（すべて必須）
+    name: string
+    birthday: string // "YYYY-MM-DD"形式
+    phone: string
+    address: string
+    email: string
+    termsAccepted: boolean
+    password: string
+    captchaVerified: boolean
+    otpVerified: boolean
+}
+
+/**
+ * 登録レスポンス（必ずエラーを返す）
+ */
+export interface RegisterErrorResponse {
+    error: true
+    message: string
+    redirect_delay: number
+}
+
+/**
+ * Register APIエラー
+ */
+export class RegisterApiError extends Error {
+    statusCode?: number
+    response?: unknown
+
+    constructor(
+        message: string,
+        statusCode?: number,
+        response?: unknown
+    ) {
+        super(message)
+        this.name = 'RegisterApiError'
+        this.statusCode = statusCode
+        this.response = response
+    }
+}
+
+// --- API関数 ---
+
+/**
+ * 会員登録を送信
+ * POST /api/register
+ * 
+ * 鬼畜仕様: 必ずサーバーエラーを返す
+ */
+export async function submitRegistration(
+    request: RegisterRequest
+): Promise<RegisterErrorResponse> {
+    const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080'
+    const url = `${API_BASE_URL}/api/register`
+
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+            body: JSON.stringify(request),
+        })
+
+        if (!response.ok) {
+            throw new RegisterApiError(
+                `Registration failed: ${response.status}`,
+                response.status
+            )
+        }
+
+        const data: RegisterErrorResponse = await response.json()
+        
+        // 必ずエラーを返す（正常系は存在しない）
+        if (!data.error) {
+            // 万が一成功レスポンスが返ってきた場合も、エラーとして扱う
+            throw new RegisterApiError('Unexpected success response')
+        }
+
+        return data
+    } catch (error) {
+        if (error instanceof RegisterApiError) {
+            throw error
+        }
+        throw new RegisterApiError(
+            error instanceof Error ? error.message : 'Unknown error occurred'
+        )
+    }
+}
+
+// --- モック関数（フロントエンド開発用） ---
+
+/**
+ * 会員登録送信（モック）
+ * 
+ * 鬼畜仕様: 必ずサーバーエラーを返す
+ */
+export async function submitRegistrationMock(): Promise<RegisterErrorResponse> {
+    // 遅延をシミュレート（1秒待機してからエラーを返す）
+    await new Promise(resolve => setTimeout(resolve, 1000))
+
+    // 必ずエラーを返す
+    return {
+        error: true,
+        message: 'サーバーエラーが発生しました。お手数ですが最初からやり直してください。',
+        redirect_delay: 3,
+    }
+}
+

--- a/src/pages/CompletePage.tsx
+++ b/src/pages/CompletePage.tsx
@@ -1,14 +1,35 @@
 /**
  * 登録完了ページ（サーバーエラー演出）
- * Issue #1: ルーティング設定
+ * Issue #24: 登録完了処理（サーバーエラー演出）
+ * 
+ * 鬼畜仕様: すべてのバリデーションが成功しても、必ずサーバーエラーが返る。
+ * 永遠に登録は完了しない。
  */
+import { useAutoRedirect } from '../hooks/useAutoRedirect'
 
 const CompletePage = () => {
+    // 3秒後にトップページ（待機列）へリダイレクト
+    const { remainingSeconds } = useAutoRedirect({
+        to: '/',
+        delay: 3000,
+        autoStart: true,
+    })
+
     return (
-        <div data-testid="complete-page" className="min-h-screen bg-gray-900 text-white flex items-center justify-center">
-            <div className="text-center">
-                <h1 className="text-4xl font-bold mb-4">登録完了</h1>
-                <p className="text-gray-400">Complete Page - Coming Soon</p>
+        <div
+            data-testid="complete-page"
+            className="min-h-screen bg-gray-900 text-white flex items-center justify-center"
+        >
+            <div className="text-center max-w-2xl px-4">
+                <h1 className="text-4xl font-bold mb-6 text-red-500">サーバーエラー</h1>
+                <div className="bg-red-900/20 border border-red-700 rounded-lg p-6 mb-6">
+                    <p className="text-lg text-red-300 mb-4">
+                        サーバーエラーが発生しました。お手数ですが最初からやり直してください。
+                    </p>
+                </div>
+                <p className="text-gray-400 text-sm">
+                    {remainingSeconds}秒後にトップページへリダイレクトします...
+                </p>
             </div>
         </div>
     )


### PR DESCRIPTION
## 概要

Issue #24の登録完了処理（サーバーエラー演出）を実装しました。

## 実装内容

### API関数
- **submitRegistration**: `/api/register` - 会員登録API呼び出し
- **submitRegistrationMock**: 開発用のモック関数

### ページ
- **CompletePage**: サーバーエラーメッセージ表示と3秒後の自動リダイレクト

### 鬼畜仕様
- すべてのバリデーションが成功しても、必ずサーバーエラーが返る
- 永遠に登録は完了しない
- 3秒後にトップページ（待機列）へ自動リダイレクト

### 機能
- POST /api/register API呼び出し
- サーバーエラーメッセージ表示
- 3秒後の自動リダイレクト（useAutoRedirectフックを使用）
- リダイレクトカウントダウン表示

## テスト
- registerApi: 11テスト すべてパス
- 登録リクエスト送信
- サーバーエラー演出（必ずエラーを返す）
- エラーハンドリング
- モック関数のテスト

## チェックリスト
- [x] Lintエラーなし
- [x] 型チェックエラーなし（ビルド成功）
- [x] テストがすべてパス
- [x] console.logなどの不要なコードを削除

## レビューポイント
- APIレスポンスが必ずエラーを返す実装
- 自動リダイレクトの実装
- エラーメッセージの表示

Closes #24