### PR TITLE
feat(birthday): add horizontal scroll bar UI for birthday input

### DIFF
--- a/src/components/register/birthday/BirthdayScrollInput.test.tsx
+++ b/src/components/register/birthday/BirthdayScrollInput.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Issue #32: feat: 生年月日入力 - 横スクロールバーUI
+ *
+ * テスト対象: BirthdayScrollInput コンポーネント
+ * - 横スクロールバーの表示
+ * - 日付の選択
+ * - スクロール位置の計算
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BirthdayScrollInput } from './BirthdayScrollInput'
+
+// 日付生成関数をモック（テスト用に少数の日付のみ生成）
+vi.mock('./generateDates', () => ({
+    generateDates: vi.fn(() => [
+        '0001-01-01',
+        '0001-01-02',
+        '0001-01-03',
+        '2025-12-19',
+        '2025-12-20',
+        '2025-12-21',
+    ]),
+}))
+
+describe('BirthdayScrollInput', () => {
+    const mockOnChange = vi.fn()
+
+    beforeEach(() => {
+        mockOnChange.mockClear()
+    })
+
+    describe('基本レンダリング', () => {
+        it('横スクロールバーが表示される', () => {
+            render(<BirthdayScrollInput value={null} onChange={mockOnChange} />)
+            expect(screen.getByTestId('birthday-scroll-container')).toBeInTheDocument()
+        })
+
+        it('日付のリストが表示される', () => {
+            render(<BirthdayScrollInput value={null} onChange={mockOnChange} />)
+            const dateItems = screen.getAllByTestId(/^birthday-date-/)
+            expect(dateItems.length).toBe(6) // モックで6つの日付を返す
+        })
+
+        it('スクロール指示が表示される', () => {
+            render(<BirthdayScrollInput value={null} onChange={mockOnChange} />)
+            expect(
+                screen.getByText('横にスクロールして日付を選択してください')
+            ).toBeInTheDocument()
+        })
+    })
+
+    describe('日付選択', () => {
+        it('日付をクリックで選択できる', () => {
+            render(<BirthdayScrollInput value={null} onChange={mockOnChange} />)
+            const dateItems = screen.getAllByTestId(/^birthday-date-/)
+            const firstDate = dateItems[0]
+            const dateValue = firstDate.getAttribute('data-date')
+
+            fireEvent.click(firstDate)
+
+            expect(mockOnChange).toHaveBeenCalledWith(dateValue)
+        })
+
+        it('選択された日付が表示される', () => {
+            render(
+                <BirthdayScrollInput
+                    value="1990-01-01"
+                    onChange={mockOnChange}
+                />
+            )
+            expect(screen.getByText('1990年1月1日')).toBeInTheDocument()
+        })
+
+        it('スクロールで日付を選択できる', () => {
+            render(
+                <BirthdayScrollInput value={null} onChange={mockOnChange} />
+            )
+
+            const scrollContainer = screen.getByTestId('birthday-scroll-container')
+            fireEvent.scroll(scrollContainer, { target: { scrollLeft: 1000 } })
+
+            // スクロールイベントが発火されることを確認
+            expect(scrollContainer).toBeInTheDocument()
+        })
+    })
+
+    describe('日付範囲', () => {
+        it('1年1月1日から始まる', () => {
+            render(<BirthdayScrollInput value={null} onChange={mockOnChange} />)
+            const dateItems = screen.getAllByTestId(/^birthday-date-/)
+            const firstDate = dateItems[0].getAttribute('data-date')
+            expect(firstDate).toBe('0001-01-01')
+        })
+
+        it('2025年12月21日で終わる', () => {
+            render(<BirthdayScrollInput value={null} onChange={mockOnChange} />)
+            const dateItems = screen.getAllByTestId(/^birthday-date-/)
+            const lastDate = dateItems[dateItems.length - 1].getAttribute('data-date')
+            expect(lastDate).toBe('2025-12-21')
+        })
+    })
+
+    describe('無効化', () => {
+        it('disabled時はクリックできない', () => {
+            render(
+                <BirthdayScrollInput
+                    value={null}
+                    onChange={mockOnChange}
+                    disabled={true}
+                />
+            )
+            const dateItems = screen.getAllByTestId(/^birthday-date-/)
+            const firstDate = dateItems[0]
+
+            fireEvent.click(firstDate)
+
+            expect(mockOnChange).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/src/components/register/birthday/BirthdayScrollInput.tsx
+++ b/src/components/register/birthday/BirthdayScrollInput.tsx
@@ -1,0 +1,176 @@
+/**
+ * BirthdayScrollInput - 生年月日横スクロールバーコンポーネント
+ * Issue #32: 生年月日入力 - 横スクロールバーUI
+ * 
+ * 機能:
+ * - 1年1月1日 〜 2025年12月21日の範囲で日付を生成
+ * - 横スクロールで日付を選択
+ * - 選択した日付を表示
+ * - 閏年は考慮しない（2月は常に28日まで）
+ */
+
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { generateDates } from './generateDates'
+
+export interface BirthdayScrollInputProps {
+    /** 選択された日付（YYYY-MM-DD形式） */
+    value: string | null
+    /** 日付選択時のコールバック */
+    onChange: (date: string) => void
+    /** 無効化されているか */
+    disabled?: boolean
+    /** カスタムクラス名 */
+    className?: string
+}
+
+
+/**
+ * 日付をフォーマット（表示用）
+ */
+function formatDate(dateString: string): string {
+    const [year, month, day] = dateString.split('-')
+    return `${year}年${parseInt(month, 10)}月${parseInt(day, 10)}日`
+}
+
+/**
+ * 生年月日横スクロールバーコンポーネント
+ */
+export const BirthdayScrollInput = ({
+    value,
+    onChange,
+    disabled = false,
+    className = '',
+}: BirthdayScrollInputProps) => {
+    const dates = useMemo(() => generateDates(), [])
+    const scrollContainerRef = useRef<HTMLDivElement>(null)
+    const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
+
+    // 初期選択位置を設定
+    useEffect(() => {
+        if (value && scrollContainerRef.current) {
+            const index = dates.indexOf(value)
+            if (index >= 0) {
+                // eslint-disable-next-line react-hooks/exhaustive-deps
+                setSelectedIndex(index)
+                // スクロール位置を設定
+                const itemWidth = 200 // 各日付アイテムの幅（px）
+                const scrollPosition = index * itemWidth - scrollContainerRef.current.clientWidth / 2 + itemWidth / 2
+                scrollContainerRef.current.scrollTo({
+                    left: Math.max(0, scrollPosition),
+                    behavior: 'auto',
+                })
+            }
+        }
+    }, [value, dates])
+
+    // スクロール位置から選択された日付を計算
+    const handleScroll = useCallback(() => {
+        if (!scrollContainerRef.current || disabled) return
+
+        const container = scrollContainerRef.current
+        const scrollLeft = container.scrollLeft
+        const itemWidth = 200 // 各日付アイテムの幅（px）
+        const centerPosition = scrollLeft + container.clientWidth / 2
+        const index = Math.round(centerPosition / itemWidth)
+        const clampedIndex = Math.max(0, Math.min(index, dates.length - 1))
+
+        if (clampedIndex !== selectedIndex) {
+            setSelectedIndex(clampedIndex)
+            onChange(dates[clampedIndex])
+        }
+    }, [onChange, disabled, selectedIndex, dates])
+
+    // 日付アイテムをクリック
+    const handleDateClick = useCallback(
+        (index: number) => {
+            if (disabled) return
+
+            setSelectedIndex(index)
+            onChange(dates[index])
+
+            // クリックした日付を中央にスクロール
+            if (scrollContainerRef.current) {
+                const itemWidth = 200
+                const scrollPosition = index * itemWidth - scrollContainerRef.current.clientWidth / 2 + itemWidth / 2
+                scrollContainerRef.current.scrollTo({
+                    left: Math.max(0, scrollPosition),
+                    behavior: 'smooth',
+                })
+            }
+        },
+        [onChange, disabled, dates]
+    )
+
+    return (
+        <div className={`${className}`}>
+            {/* 選択された日付の表示 */}
+            {value && (
+                <div className="text-center mb-6">
+                    <p className="text-2xl font-bold text-white">
+                        {formatDate(value)}
+                    </p>
+                </div>
+            )}
+
+            {/* 横スクロールバー */}
+            <div
+                ref={scrollContainerRef}
+                className="overflow-x-auto overflow-y-hidden"
+                style={{
+                    scrollbarWidth: 'thin',
+                    scrollbarColor: '#4B5563 #1F2937',
+                }}
+                onScroll={handleScroll}
+                data-testid="birthday-scroll-container"
+            >
+                <div className="flex items-center h-32 px-4" style={{ width: `${dates.length * 200}px` }}>
+                    {dates.map((date, index) => {
+                        const isSelected = selectedIndex === index
+                        const distance = selectedIndex !== null ? Math.abs(index - selectedIndex) : Infinity
+                        const opacity = distance <= 2 ? 1 : Math.max(0.3, 1 - distance * 0.2)
+                        const scale = isSelected ? 1.2 : Math.max(0.8, 1 - distance * 0.1)
+
+                        return (
+                            <button
+                                key={date}
+                                data-testid={`birthday-date-${index}`}
+                                data-date={date}
+                                onClick={() => handleDateClick(index)}
+                                disabled={disabled}
+                                className={`
+                                    flex-shrink-0 w-48 h-24 mx-2 rounded-lg border-2 transition-all
+                                    ${isSelected
+                                        ? 'border-blue-500 bg-blue-500/20 scale-110'
+                                        : 'border-gray-700 bg-gray-800 hover:border-gray-600'
+                                    }
+                                    ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+                                    focus:outline-none focus:ring-2 focus:ring-blue-500
+                                `}
+                                style={{
+                                    opacity,
+                                    transform: `scale(${scale})`,
+                                }}
+                                type="button"
+                            >
+                                <div className="flex flex-col items-center justify-center h-full">
+                                    <p className="text-sm text-gray-400">{formatDate(date)}</p>
+                                    {isSelected && (
+                                        <p className="text-xs text-blue-400 mt-1">選択中</p>
+                                    )}
+                                </div>
+                            </button>
+                        )
+                    })}
+                </div>
+            </div>
+
+            {/* スクロール指示 */}
+            <p className="text-center text-sm text-gray-400 mt-4">
+                横にスクロールして日付を選択してください
+            </p>
+        </div>
+    )
+}
+
+export default BirthdayScrollInput
+

--- a/src/components/register/birthday/generateDates.ts
+++ b/src/components/register/birthday/generateDates.ts
@@ -1,0 +1,29 @@
+/**
+ * 日付を生成（1年1月1日 〜 2025年12月21日）
+ * 閏年は考慮しない（2月は常に28日まで）
+ * 
+ * 注意: 約73万個の日付を生成するため、メモリ使用量に注意
+ */
+export function generateDates(): string[] {
+    const dates: string[] = []
+    const startYear = 1
+    const endYear = 2025
+    const endMonth = 12
+    const endDay = 21
+
+    // 各月の日数（閏年を考慮しない）
+    const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+    for (let year = startYear; year <= endYear; year++) {
+        const maxMonth = year === endYear ? endMonth : 12
+        for (let month = 1; month <= maxMonth; month++) {
+            const maxDay = year === endYear && month === endMonth ? endDay : daysInMonth[month - 1]
+            for (let day = 1; day <= maxDay; day++) {
+                dates.push(`${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`)
+            }
+        }
+    }
+
+    return dates
+}
+

--- a/src/pages/RegisterBirthdayPage.test.tsx
+++ b/src/pages/RegisterBirthdayPage.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Issue #32: feat: 生年月日入力 - 横スクロールバーUI
+ *
+ * テスト対象: RegisterBirthdayPage コンポーネント
+ * - ページの基本レンダリング
+ * - 日付選択とタスク完了
+ * - ダッシュボードへの戻り
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import RegisterBirthdayPage from './RegisterBirthdayPage'
+import { useRegistrationStore } from '../store/registrationStore'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual('react-router-dom')
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
+    }
+})
+
+describe('RegisterBirthdayPage', () => {
+    beforeEach(() => {
+        mockNavigate.mockClear()
+        useRegistrationStore.getState().resetAllTasks()
+    })
+
+    describe('基本レンダリング', () => {
+        it('生年月日入力ページが表示される', () => {
+            render(
+                <MemoryRouter>
+                    <RegisterBirthdayPage />
+                </MemoryRouter>
+            )
+            expect(screen.getByTestId('register-birthday-page')).toBeInTheDocument()
+        })
+
+        it('タイトルが表示される', () => {
+            render(
+                <MemoryRouter>
+                    <RegisterBirthdayPage />
+                </MemoryRouter>
+            )
+            expect(screen.getByText('生年月日入力')).toBeInTheDocument()
+        })
+
+        it('横スクロールバーが表示される', () => {
+            render(
+                <MemoryRouter>
+                    <RegisterBirthdayPage />
+                </MemoryRouter>
+            )
+            expect(screen.getByTestId('birthday-scroll-container')).toBeInTheDocument()
+        })
+
+        it('戻るボタンが表示される', () => {
+            render(
+                <MemoryRouter>
+                    <RegisterBirthdayPage />
+                </MemoryRouter>
+            )
+            expect(screen.getByTestId('back-to-dashboard-button')).toBeInTheDocument()
+        })
+    })
+
+    describe('日付選択', () => {
+        it('日付を選択するとタスクが完了する', () => {
+            render(
+                <MemoryRouter>
+                    <RegisterBirthdayPage />
+                </MemoryRouter>
+            )
+
+            const dateItems = screen.getAllByTestId(/^birthday-date-/)
+            const firstDate = dateItems[0]
+            fireEvent.click(firstDate)
+
+            // タスクが完了していることを確認
+            expect(useRegistrationStore.getState().tasks.birthday.status).toBe('completed')
+        })
+
+        it('選択した日付がフォームデータに保存される', () => {
+            render(
+                <MemoryRouter>
+                    <RegisterBirthdayPage />
+                </MemoryRouter>
+            )
+
+            const dateItems = screen.getAllByTestId(/^birthday-date-/)
+            const firstDate = dateItems[0]
+            const dateValue = firstDate.getAttribute('data-date')
+
+            fireEvent.click(firstDate)
+
+            expect(useRegistrationStore.getState().formData.birthday).toBe(dateValue)
+        })
+    })
+
+    describe('ナビゲーション', () => {
+        it('戻るボタンでダッシュボードに戻る', () => {
+            render(
+                <MemoryRouter>
+                    <RegisterBirthdayPage />
+                </MemoryRouter>
+            )
+
+            const backButton = screen.getByTestId('back-to-dashboard-button')
+            fireEvent.click(backButton)
+
+            expect(mockNavigate).toHaveBeenCalledWith('/register')
+        })
+    })
+})
+

--- a/src/pages/RegisterBirthdayPage.tsx
+++ b/src/pages/RegisterBirthdayPage.tsx
@@ -1,20 +1,64 @@
 /**
- * RegisterBirthdayPage - 生年月日入力ページ（プレースホルダー）
- * Issue #37: 登録ダッシュボード（ハブ＆スポーク形式）
- *
- * TODO: 後続のissueで実装予定（横スクロールバー）
+ * RegisterBirthdayPage - 生年月日入力ページ
+ * Issue #32: 生年月日入力 - 横スクロールバーUI
+ * 
+ * 機能:
+ * - 横スクロールバーで日付を選択
+ * - 選択した日付をregistrationStoreに保存
+ * - タスク完了としてマーク
  */
 
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useRegistrationStore } from '../store/registrationStore'
+import { BirthdayScrollInput } from '../components/register/birthday/BirthdayScrollInput'
+
 const RegisterBirthdayPage = () => {
+    const navigate = useNavigate()
+    const { formData, completeTask } = useRegistrationStore()
+
+    // 日付選択時のハンドラ
+    const handleDateChange = useCallback(
+        (date: string) => {
+            // フォームデータを更新してタスクを完了
+            completeTask('birthday', { birthday: date })
+        },
+        [completeTask]
+    )
+
+    // 戻るボタン（ダッシュボードへ）
+    const handleBack = useCallback(() => {
+        navigate('/register')
+    }, [navigate])
+
     return (
-        <div data-testid="register-birthday-page" className="min-h-screen bg-gray-900 text-white flex items-center justify-center">
-            <div className="text-center">
-                <h1 className="text-4xl font-bold mb-4">生年月日入力</h1>
-                <p className="text-gray-400">Coming Soon</p>
+        <div
+            data-testid="register-birthday-page"
+            className="min-h-screen bg-gray-900 text-white py-8 px-4"
+        >
+            <div className="max-w-4xl mx-auto">
+                <h1 className="text-3xl font-bold text-center mb-8">生年月日入力</h1>
+
+                {/* 横スクロールバー */}
+                <BirthdayScrollInput
+                    value={formData.birthday}
+                    onChange={handleDateChange}
+                />
+
+                {/* 戻るボタン */}
+                <div className="text-center mt-8">
+                    <button
+                        data-testid="back-to-dashboard-button"
+                        onClick={handleBack}
+                        className="px-6 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        type="button"
+                    >
+                        ダッシュボードに戻る
+                    </button>
+                </div>
             </div>
         </div>
     )
 }
 
 export default RegisterBirthdayPage
-


### PR DESCRIPTION
## 概要

Issue #32の生年月日入力 - 横スクロールバーUIを実装しました。

## 実装内容

### コンポーネント
- **BirthdayScrollInput**: 横スクロールバーで日付を選択するコンポーネント
- **RegisterBirthdayPage**: 生年月日入力ページ（BirthdayScrollInputを統合）

### 機能
- 1年1月1日 〜 2025年12月21日の範囲で日付を生成（約73万日）
- 横スクロールで日付を選択
- クリックで日付を選択
- 選択中の日付をハイライト表示
- 選択した日付をregistrationStoreに保存
- タスク完了としてマーク

### 仕様
- 閏年は考慮しない（2月は常に28日まで）
- 日付はYYYY-MM-DD形式で保存
- スクロール位置から自動的に選択日付を計算

### テスト
- BirthdayScrollInput: 9テスト すべてパス
- RegisterBirthdayPage: 7テスト すべてパス

## チェックリスト
- [x] Lintエラーなし（警告のみ、許容範囲）
- [x] テストがすべてパス
- [x] console.logなどの不要なコードを削除

## レビューポイント
- 約73万個の日付を生成するため、メモリ使用量に注意
- テストではgenerateDatesをモックして少数の日付のみ生成

Closes #32